### PR TITLE
Ambiguous statement replaced

### DIFF
--- a/Tema_04/GaussianCuadratureAndFitting.ipynb
+++ b/Tema_04/GaussianCuadratureAndFitting.ipynb
@@ -38,7 +38,7 @@
     "Por el otro lado, para la cuadratura Gaussiana:\n",
     "  * Los puntos de muestreo se escogen de manera tal que **no son equidistantes**. Esto introduce más grados de libertad para la misma discretización en $N$ subregiones.\n",
     "  * Es exacta para un polinomio de orden $(2N - 1)$.\n",
-    "  * Es decir, la cuadratura Gaussiana da la misma precisión que un polinomio de orden $(2N - 1)$."
+    "  * Es decir, la cuadratura gaussiana con $N$ puntos es exacta para cualquier polinomio de grado hasta $(2N - 1)$."
    ]
   },
   {
@@ -527,9 +527,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:base] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -541,9 +541,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
En  `Tema 4` , el jupyter notebook de Cuadratura Gaussiana tiene un _statement_ ambiguo:

> Es decir, la cuadratura Gaussiana da la misma precisión que un polinomio de orden $(2N - 1)$.

Para mayor claridad, se sugiere cambiarlo por:

> Es decir, la cuadratura gaussiana con $N$ puntos es exacta para cualquier polinomio de grado hasta $(2N - 1)$.

